### PR TITLE
Added support for seconds in UTCOffset

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -1259,6 +1259,9 @@ class vUTCOffset:
     >>> vUTCOffset.from_ical('+0200')
     datetime.timedelta(0, 7200)
 
+    >>> vUTCOffset.from_ical('+023040')
+    datetime.timedelta(0, 9040)
+
     >>> o = vUTCOffset.from_ical('+0230')
     >>> vUTCOffset(o).ical()
     '+0230'
@@ -1300,8 +1303,8 @@ class vUTCOffset:
     def from_ical(ical):
         "Parses the data format from ical text format"
         try:
-            sign, hours, minutes = (ical[-5:-4], int(ical[-4:-2]), int(ical[-2:]))
-            offset = timedelta(hours=hours, minutes=minutes)
+            sign, hours, minutes, seconds = (ical[0:1], int(ical[1:3]), int(ical[3:5]), int(ical[5:7] or 0))
+            offset = timedelta(hours=hours, minutes=minutes, seconds=seconds)
         except:
             raise ValueError, 'Expected utc offset, got: %s' % ical
         if offset >= timedelta(hours=24):


### PR DESCRIPTION
According to http://www.kanzaki.com/docs/ical/utcOffset.html utc-offset can contain optional seconds part.
And seems like new iCal from well known fruit company uses it.

Simple test case included.
